### PR TITLE
Clean retained message by specified topic

### DIFF
--- a/src/emqx_retainer_cli.erl
+++ b/src/emqx_retainer_cli.erl
@@ -41,10 +41,15 @@ cmd(["clean"]) ->
         {aborted, R} -> emqx_cli:print("Aborted ~p~n", [R])
     end;
 
+cmd(["clean", Topic]) ->
+    Lines = emqx_retainer:clean(list_to_binary(Topic)),
+    emqx_cli:print("Cleaned ~p retained messages~n", [Lines]);
+
 cmd(_) ->
     emqx_cli:usage([{"retainer info",   "Show the count of retained messages"},
                     {"retainer topics", "Show all topics of retained messages"},
-                    {"retainer clean",  "Clean all retained messages"}]).
+                    {"retainer clean",  "Clean all retained messages"},
+                    {"retainer clean <Topic>",  "Clean retained messages by the specified topic filter"}]).
 
 unload() ->
     emqx_ctl:unregister_command(retainer).


### PR DESCRIPTION
For https://github.com/emqx/emqx/issues/2492.

In this feature, we can use CLI to clean retained messages by a specified topic filter:

```bash
emqx_ctl retainer clean <Topic>    # Clean retained messages by the specified topic filter
```